### PR TITLE
Child Params and More

### DIFF
--- a/src/NetHierarchy/Helpers.cs
+++ b/src/NetHierarchy/Helpers.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NetHierarchy
+{
+    internal static class Helpers
+    {
+        /// <summary>
+        /// Extension method to help with null checking.
+        /// </summary>
+        internal static void ArgumentNullCheck(this object obj, string name)
+        {
+            if (obj == null)
+                throw new ArgumentNullException(name);
+        }
+    }
+}

--- a/src/NetHierarchy/NetHierarchy.csproj
+++ b/src/NetHierarchy/NetHierarchy.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helpers.cs" />
     <Compile Include="Node.cs" />
     <Compile Include="NodeLinq.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/NetHierarchy/Node.cs
+++ b/src/NetHierarchy/Node.cs
@@ -102,6 +102,7 @@ namespace NetHierarchy
         /// <param name="Children">Collection of Child nodes that belong to this node.</param>
         public Node(ICollection<Node<T>> Children)
         {
+            Children.ArgumentNullCheck(nameof(Children));
             this.Children = Children;
             foreach (var child in this.Children)
                 if (child.Parent != this)
@@ -154,7 +155,7 @@ namespace NetHierarchy
         /// <param name="ChildNode">The child item to add.</param>
         public void AddChild(Node<T> ChildNode)
         {
-            if (ChildNode == null) throw new ArgumentNullException(nameof(ChildNode));
+            ChildNode.ArgumentNullCheck(nameof(ChildNode));
 
             this.Children.Add(ChildNode);
             ChildNode.Parent = this;
@@ -170,6 +171,21 @@ namespace NetHierarchy
 
             this.Children.Add(childNode);
             childNode.Parent = this;
+        }
+
+        /// <summary>
+        /// Add a collection of children to this node and create a parent/child relationship between the nodes.
+        /// </summary>
+        /// <param name="ChildNodes">A collection of <see cref="Node{T}"/> to add.</param>
+        public void AddChild(params Node<T>[] ChildNodes)
+        {
+            ChildNodes.ArgumentNullCheck(nameof(ChildNodes));
+
+            foreach(var node in ChildNodes)
+            {
+                this.Children.Add(node);
+                node.Parent = this;
+            }
         }
 
         /// <summary>
@@ -209,7 +225,7 @@ namespace NetHierarchy
         /// <param name="Check">The <see cref="Node{T}"/> to check under.</param>
         public bool IsDescendantOf(Node<T> Check)
         {
-            if (Check == null) throw new ArgumentNullException(nameof(Check));
+            Check.ArgumentNullCheck(nameof(Check));
 
             //No parent then it is not a descendant of anything.
             if (this.Parent == null)
@@ -255,11 +271,17 @@ namespace NetHierarchy
         #endregion
 
         #region Object Overrides
+        /// <summary>
+        /// Returns a string that represents the object.
+        /// </summary>
         public override string ToString()
         {
             return this.Data.ToString();
         }
 
+        /// <summary>
+        /// Determines if the supplied object is equal to the current object.
+        /// </summary>
         public override bool Equals(object obj)
         {
             if (obj == null)
@@ -272,6 +294,9 @@ namespace NetHierarchy
             return this.Data.Equals(n.Data);
         }
 
+        /// <summary>
+        /// Returns the hash code of the Node's data.
+        /// </summary>
         public override int GetHashCode()
         {
             return this.Data.GetHashCode();

--- a/src/NetHierarchy/NodeLinq.cs
+++ b/src/NetHierarchy/NodeLinq.cs
@@ -14,10 +14,12 @@ namespace NetHierarchy
         /// <summary>
         /// Filters the descendant nodes based on a predicate.
         /// </summary>
+        /// <param name="node">The <see cref="Node{T}"/> to act upon.</param>
         /// <param name="Predicate">A function to test each descendant for a condition.</param>
         public static IEnumerable<Node<T>> DescendantsWhere<T>(this Node<T> node, Func<Node<T>, bool> Predicate)
         {
-            if (Predicate == null) throw new ArgumentNullException(nameof(Predicate));
+            node.ArgumentNullCheck(nameof(node));
+            Predicate.ArgumentNullCheck(nameof(Predicate));
 
             if (Predicate(node))
                 yield return node;
@@ -34,10 +36,12 @@ namespace NetHierarchy
         /// <summary>
         /// Determines whether any descendant satisfies a condition.
         /// </summary>
+        /// <param name="node">The <see cref="Node{T}"/> to act upon.</param>
         /// <param name="Predicate">A function to test each descendant.</param>
         public static bool DescendantsAny<T>(this Node<T> node, Func<Node<T>, bool> Predicate)
         {
-            if (Predicate == null) throw new ArgumentNullException(nameof(Predicate));
+            node.ArgumentNullCheck(nameof(node));
+            Predicate.ArgumentNullCheck(nameof(Predicate));
 
             if (Predicate(node))
                 return true;
@@ -55,9 +59,11 @@ namespace NetHierarchy
         /// <summary>
         /// Determines if the node's descendants contains the value using the default equality comparer.
         /// </summary>
+        /// <param name="node">The <see cref="Node{T}"/> to act upon.</param>
         /// <param name="Value">The value to locate in the sequence.</param>
         public static bool DescendantsContains<T>(this Node<T> node, T Value)
         {
+            node.ArgumentNullCheck(nameof(node));
             if (Value == null) return false;
 
             if (node.Data.Equals(Value))
@@ -76,10 +82,12 @@ namespace NetHierarchy
         /// <summary>
         /// Filters the parent nodes based on a predicate.
         /// </summary>
+        /// <param name="node">The <see cref="Node{T}"/> to act upon.</param>
         /// <param name="Predicate">A function to test each parent for a condition.</param>
         public static IEnumerable<Node<T>> ParentsWhere<T>(this Node<T> node, Func<Node<T>, bool> Predicate)
         {
-            if (Predicate == null) throw new ArgumentNullException(nameof(Predicate));
+            node.ArgumentNullCheck(nameof(node));
+            Predicate.ArgumentNullCheck(nameof(Predicate));
 
             if (node.Parent == null)
                 yield break;
@@ -94,18 +102,22 @@ namespace NetHierarchy
         /// <summary>
         /// Determines if a node's parents contains any value.
         /// </summary>
+        /// <param name="node">The <see cref="Node{T}"/> to act upon.</param>
         public static bool ParentsAny<T>(this Node<T> node)
         {
+            node.ArgumentNullCheck(nameof(node));
             return node.Parent != null;
         }
 
         /// <summary>
         /// Determines whether any parent satisfies a condition.
         /// </summary>
+        /// <param name="node">The <see cref="Node{T}"/> to act upon.</param>
         /// <param name="Predicate">A function to test each parent.</param>
         public static bool ParentsAny<T>(this Node<T> node, Func<Node<T>, bool> Predicate)
         {
-            if (Predicate == null) throw new ArgumentNullException(nameof(Predicate));
+            node.ArgumentNullCheck(nameof(node));
+            Predicate.ArgumentNullCheck(nameof(Predicate));
 
             if (node.Parent == null)
                 return false;
@@ -119,9 +131,11 @@ namespace NetHierarchy
         /// <summary>
         /// Determines if the node's parents contains the value using the default equality comparer.
         /// </summary>
+        /// <param name="node">The <see cref="Node{T}"/> to act upon.</param>
         /// <param name="Value">The value to locate in the sequence.</param>
         public static bool ParentsContains<T>(this Node<T> node, T Value)
         {
+            node.ArgumentNullCheck(nameof(node));
             if (Value == null) return false;
 
             if (node.Parent == null)

--- a/src/NetHierarchy/Serialization/SerializableNode.cs
+++ b/src/NetHierarchy/Serialization/SerializableNode.cs
@@ -49,6 +49,7 @@ namespace NetHierarchy.Serialization
         /// <param name="Children">An <see cref="ICollection{T}"/> of <see cref="SerializableNode{T}"/> that are children to this node.</param>
         public SerializableNode(T Data, List<SerializableNode<T>> Children)
         {
+            Children.ArgumentNullCheck(nameof(Children));
             this.Data = Data;
             this.Children = Children;
         }
@@ -62,8 +63,34 @@ namespace NetHierarchy.Serialization
         /// <param name="ChildNode">The child node to add.</param>
         public void AddChild(SerializableNode<T> ChildNode)
         {
+            ChildNode.ArgumentNullCheck(nameof(ChildNode));
+
             this.Children.Add(ChildNode);
         }
+
+        /// <summary>
+        /// Add a child <see cref="SerializableNode{T}"/> with given data under the current node.
+        /// </summary>
+        /// <param name="ChildData">That data that the child <see cref="SerializableNode{T}"/> will contain.</param>
+        public void AddChild(T ChildData)
+        {
+            this.Children.Add(new SerializableNode<T>(ChildData));
+        }
+
+        /// <summary>
+        /// Add a collection of <see cref="SerializableNode{T}"/> under the current node.
+        /// </summary>
+        /// <param name="ChildNodes">A collection of children to add.</param>
+        public void AddChild(params SerializableNode<T>[] ChildNodes)
+        {
+            ChildNodes.ArgumentNullCheck(nameof(ChildNodes));
+
+            foreach(var child in ChildNodes)
+            {
+                this.Children.Add(child);
+            }
+        }
+
         #endregion
 
         #region Cast Methods
@@ -92,6 +119,9 @@ namespace NetHierarchy.Serialization
         #endregion
 
         #region Object Overrides
+        /// <summary>
+        /// Returns a string representation of the object.
+        /// </summary>
         public override string ToString()
         {
             return this.Data.ToString();

--- a/src/NetHierarchyTests/NodeLinq_Tests.cs
+++ b/src/NetHierarchyTests/NodeLinq_Tests.cs
@@ -9,6 +9,15 @@ namespace NetHierarchyTests
     public class NodeLinq_Tests
     {
         [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void NodeLinq_NodeNullCheck()
+        {
+            Node<int> node = null;
+
+            node.DescendantsWhere(x => x.Data == 1).ToList();
+        }
+
+        [TestMethod]
         public void NodeLinq_DescendantsWhere()
         {
             var root = new Node<int>(1);

--- a/src/NetHierarchyTests/Node_Tests.cs
+++ b/src/NetHierarchyTests/Node_Tests.cs
@@ -163,6 +163,27 @@ namespace NetHierarchyTests
         }
 
         [TestMethod]
+        public void Node_AddChild_Data()
+        {
+            var node = new Node<int>(1);
+
+            node.AddChild(1);
+
+            Assert.AreEqual(1, node.Children.ElementAt(0).Data);
+        }
+
+        [TestMethod]
+        public void Node_AddChild_Params()
+        {
+            var node = new Node<int>(123);
+
+            node.AddChild(new Node<int>(1), new Node<int>(2), new Node<int>(3));
+
+            Assert.AreEqual(3, node.Children.Count);
+            Assert.AreEqual(1, node.Children.ElementAt(0).Data);
+        }
+
+        [TestMethod]
         public void Node_GetDescendants()
         {
             var root = new Node<string>("Root");
@@ -335,6 +356,16 @@ namespace NetHierarchyTests
             Assert.AreEqual(1, root.Children.Count);
             Assert.AreEqual("ASDF", actual.Data);
             Assert.AreEqual("Child", actual.Children.First().Data);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(NullReferenceException))]
+        public void Node_Cast_SerializableNode_Null()
+        {
+            Node<string> node = null;
+
+            var actual = (SerializableNode<string>)node;
+
         }
         #endregion
 

--- a/src/NetHierarchyTests/SerializableNode_Tests.cs
+++ b/src/NetHierarchyTests/SerializableNode_Tests.cs
@@ -54,6 +54,27 @@ namespace NetHierarchyTests
         }
 
         [TestMethod]
+        public void SerializableNode_AddChild_Data()
+        {
+            var node = new SerializableNode<int>(1);
+
+            node.AddChild(1);
+
+            Assert.AreEqual(1, node.Children.ElementAt(0).Data);
+        }
+
+        [TestMethod]
+        public void SerializableNode_AddChild_Params()
+        {
+            var node = new SerializableNode<int>(2);
+
+            node.AddChild(new SerializableNode<int>(1), new SerializableNode<int>(23));
+
+            Assert.AreEqual(2, node.Children.Count);
+            Assert.AreEqual(1, node.Children.ElementAt(0).Data);
+        }
+
+        [TestMethod]
         public void SerializableNode_AsNode()
         {
             var node = new SerializableNode<string>("Parent");


### PR DESCRIPTION
- Added params[] syntax to the AddChild methods.
- Added better null checking in LINQ extension methods.
- Updated XML documentation. Should no longer give warning on build.
- Added unit tests to AddChild() methods. Should have full Code Coverage.
