### PR TITLE
Argument Null Hierarchy Builder

### DIFF
--- a/src/NetHierarchy/HierarchyBuilder.cs
+++ b/src/NetHierarchy/HierarchyBuilder.cs
@@ -44,6 +44,10 @@ namespace NetHierarchy
         public static Node<T> GenerateHierarchy<T, TKey>(IEnumerable<T> collection, Func<T, TKey> primaryKey, Func<T, TKey> parentKey, TKey rootParentValue)
             where T: class
         {
+            collection.ArgumentNullCheck(nameof(collection));
+            primaryKey.ArgumentNullCheck(nameof(primaryKey));
+            parentKey.ArgumentNullCheck(nameof(parentKey));
+
             var groups = collection.GroupBy(x => parentKey(x));
 
             //Get all elements with a null primary key.
@@ -97,6 +101,10 @@ namespace NetHierarchy
         /// <returns>Returns an <see cref="Enumerable"/> collection of root nodes populated from the input collection.</returns>
         public static IEnumerable<Node<T>> GenerateHierarchies<T, TKey>(IEnumerable<T> collection, Func<T, TKey> primaryKey, Func<T, TKey> parentKey, TKey rootParentValue)
         {
+            collection.ArgumentNullCheck(nameof(collection));
+            primaryKey.ArgumentNullCheck(nameof(primaryKey));
+            parentKey.ArgumentNullCheck(nameof(parentKey));
+
             var groups = collection.GroupBy(x => parentKey(x));
 
             //Get all elements with a null primary key.

--- a/src/NetHierarchyTests/HierarchyBuilder_Tests.cs
+++ b/src/NetHierarchyTests/HierarchyBuilder_Tests.cs
@@ -284,5 +284,57 @@ namespace NetHierarchyTests
         }
 
         #endregion
+
+        #region Argument NullTests
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void HierarchyBuilder_GenerateHierarchy_CollectionNull()
+        {
+            var actual = HierarchyBuilder.GenerateHierarchy<TestData, int?>(null, x => x.Id, x => x.ParentId, -1337);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void HierarchyBuilder_GenerateHierarchy_PrimaryKeyNull()
+        {
+            var data = new List<TestData>();
+
+            var actual = HierarchyBuilder.GenerateHierarchy(data, null, x => x.ParentId, -1337);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void HierarchyBuilder_GenerateHierarchy_ParentKeyNulll()
+        {
+            var data = new List<TestData>();
+
+            var actual = HierarchyBuilder.GenerateHierarchy(data, x => x.Id, null, -1337);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void HierarchyBuilder_GenerateHierarchies_CollectionNull()
+        {
+            var actual = HierarchyBuilder.GenerateHierarchies<TestData, int?>(null, x => x.Id, x => x.ParentId, -1337).ToList();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void HierarchyBuilder_GenerateHierarchies_PrimaryKeyNull()
+        {
+            var data = new List<TestData>();
+
+            var actual = HierarchyBuilder.GenerateHierarchies(data, null, x => x.ParentId, -1337).ToList();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void HierarchyBuilder_GenerateHierarchies_ParentKeyNulll()
+        {
+            var data = new List<TestData>();
+
+            var actual = HierarchyBuilder.GenerateHierarchies(data, x => x.Id, null, -1337).ToList();
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
* Added argument null checks in hierarchy builder public methods.

Resolves #7 