### PR TITLE
Null Ref fix

### DIFF
--- a/src/NetHierarchy/HierarchyBuilder.cs
+++ b/src/NetHierarchy/HierarchyBuilder.cs
@@ -51,7 +51,7 @@ namespace NetHierarchy
             var groups = collection.GroupBy(x => parentKey(x));
 
             //Get all elements with a null primary key.
-            var root = groups.FirstOrDefault(x => x.Key.Equals(rootParentValue));
+            var root = groups.FirstOrDefault(x => EqualityComparer<TKey>.Default.Equals(x.Key, rootParentValue));
             if(root == null)
             {
                 throw new HierarchyBuilderException("A root node was not found in the collection.");
@@ -108,7 +108,7 @@ namespace NetHierarchy
             var groups = collection.GroupBy(x => parentKey(x));
 
             //Get all elements with a null primary key.
-            var roots = groups.FirstOrDefault(x => x.Key.Equals(rootParentValue));
+            var roots = groups.FirstOrDefault(x => EqualityComparer<TKey>.Default.Equals(x.Key, rootParentValue));
             if (roots == null)
             {
                 throw new HierarchyBuilderException("A root node was not found in the collection.");

--- a/src/NetHierarchyTests/HierarchyBuilder_Tests.cs
+++ b/src/NetHierarchyTests/HierarchyBuilder_Tests.cs
@@ -3,6 +3,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NetHierarchy;
 using System.Collections.Generic;
 using System.Linq;
+using System.Dynamic;
 
 namespace NetHierarchyTests
 {
@@ -334,6 +335,24 @@ namespace NetHierarchyTests
             var data = new List<TestData>();
 
             var actual = HierarchyBuilder.GenerateHierarchies(data, x => x.Id, null, -1337).ToList();
+        }
+        #endregion
+
+        #region Dynamic Tests
+        [TestMethod]
+        public void HierarchyBuilder_Dynamic()
+        {
+            dynamic rootData = new ExpandoObject();
+            rootData.Id = 1;
+            rootData.PId = null;
+            dynamic childData = new ExpandoObject();
+            childData.Id = 2;
+            childData.PId = 1;
+            var input = new List<dynamic> { rootData, childData };
+
+            var actual = HierarchyBuilder.GenerateHierarchy(input, x => x.Id, x => x.PId, null);
+
+            Assert.AreEqual(1, actual.Data.Id);
         }
         #endregion
     }

--- a/src/NetHierarchyTests/NetHierarchyTests.csproj
+++ b/src/NetHierarchyTests/NetHierarchyTests.csproj
@@ -35,6 +35,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
* Changing how the grouping keys are compared to the primaryKeyValue param.
* Added unit tests that would cause the issue without the above fix.
* Added reference to Microsoft.CSharp in tests to use dynamic object in
tests.

Fixes #9 